### PR TITLE
映画を探すページのModalをマイページで表示可能に

### DIFF
--- a/app/(inNavBar)/(inPublic)/mypage/@modal/(..)public-movie/page.tsx
+++ b/app/(inNavBar)/(inPublic)/mypage/@modal/(..)public-movie/page.tsx
@@ -1,0 +1,16 @@
+import { Modal } from '@/app/components/Modal'
+import { PublicMovieList } from '@/app/features/public-movie/PublicMovies'
+import { getAllPublicMovies } from '@/app/features/public-movie/getAllPublicMovies'
+import type { PublicMovie } from '@/app/features/public-movie/getAllPublicMovies'
+
+export default async function PublicMovie() {
+  const publicMovies = await getAllPublicMovies()
+
+  return (
+    <>
+      <Modal>
+        <PublicMovieList publicMovies={publicMovies} />
+      </Modal>
+    </>
+  )
+}

--- a/app/(inNavBar)/(inPublic)/public-movie/default.tsx
+++ b/app/(inNavBar)/(inPublic)/public-movie/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/app/features/public-movie/PublicMovies.tsx
+++ b/app/features/public-movie/PublicMovies.tsx
@@ -33,7 +33,7 @@ export function PublicMovieList(props: Props) {
 
   return (
     <>
-      <div>
+      <div className="mt-12">
         <form className={styles.form} action={formAction}>
           <div className={styles.searchArea}>
             <svg


### PR DESCRIPTION
マイページで「映画を探す」ページのModal表示を可能にしました。
マイページから映画情報の登録が可能になります。